### PR TITLE
Establish primary/default button hierarchy and round button corners

### DIFF
--- a/config/theme.tokens.opera.json
+++ b/config/theme.tokens.opera.json
@@ -7,7 +7,7 @@
         "button-bg": "#6e0e0a",
         "button-text": "#ffffff",
         "button-bg-hover": "#580b08",
-        "button-border-radius": "0",
+        "button-border-radius": "0.25rem",
         "button-text-transform": "uppercase",
         "link-color": "#6e0e0a",
         "link-color-hover": "#580b08",

--- a/css/component/backdrop-form.css
+++ b/css/component/backdrop-form.css
@@ -153,22 +153,31 @@ ul.tips {
 
 input.form-submit,
 button.form-submit,
+input.button-primary,
+button.button-primary,
 .button {
   display: inline-block;
   text-align: center;
   text-transform: uppercase;
   letter-spacing: 0.025em;
   line-height: 1.4;
-  border: 0;
+  box-sizing: border-box;
+  /* Border color is set per-variant in skin.css (outlined default vs filled
+     primary). Keep box dimensions consistent across variants by reserving
+     the border slot here via box-sizing. */
   padding: 0.75em 1.5625em;
   margin-bottom: 1em;
   margin-right: 1em; /* LTR */
   -webkit-transition:
-    background-color 0.6s ease 0s,
-    color 0.6s ease 0s;
+    background-color 0.3s ease 0s,
+    color 0.3s ease 0s,
+    border-color 0.3s ease 0s,
+    box-shadow 0.3s ease 0s;
   transition:
-    background-color 0.6s ease 0s,
-    color 0.6s ease 0s;
+    background-color 0.3s ease 0s,
+    color 0.3s ease 0s,
+    border-color 0.3s ease 0s,
+    box-shadow 0.3s ease 0s;
 }
 
 [dir="rtl"] input.form-submit,
@@ -259,7 +268,7 @@ input.form-file::file-selector-button {
   background-color: var(--button-bg, #6e0e0a);
   color: var(--button-text, #fff);
   border: none;
-  border-radius: var(--button-border-radius, 0);
+  border-radius: var(--button-border-radius, 0.25rem);
   font-size: 0.875em;
   font-weight: 600;
   text-transform: uppercase;

--- a/css/component/book.css
+++ b/css/component/book.css
@@ -76,7 +76,7 @@
   max-width: 100%;
   padding: 0.2em 0.9em;
   border: 1px solid var(--button-bg, #6e0e0a);
-  border-radius: var(--button-border-radius, 0);
+  border-radius: var(--button-border-radius, 0.25rem);
   font-size: 0.85rem;
   font-weight: 600;
   line-height: 1.4;

--- a/css/component/pager.css
+++ b/css/component/pager.css
@@ -52,7 +52,7 @@ ul.pager {
   height: 2.1rem;
   padding: 0 0.4rem;
   border: 1px solid var(--color-surface-mid, #e0d0d0);
-  border-radius: var(--button-border-radius, 0);
+  border-radius: var(--button-border-radius, 0.25rem);
   font-size: 0.9rem;
   text-decoration: none;
   color: var(--color-primary, #6e0e0a);
@@ -92,7 +92,7 @@ ul.pager {
   text-decoration: none;
   color: var(--color-primary, #6e0e0a);
   border: 1px solid transparent;
-  border-radius: var(--button-border-radius, 0);
+  border-radius: var(--button-border-radius, 0.25rem);
   white-space: nowrap;
   transition: border-color 0.15s ease, background-color 0.15s ease;
 }

--- a/css/component/teasers.css
+++ b/css/component/teasers.css
@@ -77,7 +77,7 @@
 .view-mode-teaser .node-readmore a:visited {
   display: inline-block;
   padding: 0.25em 1em;
-  border-radius: var(--button-border-radius, 0);
+  border-radius: var(--button-border-radius, 0.25rem);
   font-size: 0.85rem;
   font-weight: 600;
   text-decoration: none;
@@ -107,7 +107,7 @@
 .view-mode-teaser .links .comment-add a:visited {
   display: inline-block;
   padding: 0.25em 1em;
-  border-radius: var(--button-border-radius, 0);
+  border-radius: var(--button-border-radius, 0.25rem);
   font-size: 0.85rem;
   font-weight: 600;
   text-decoration: none;

--- a/css/skin.css
+++ b/css/skin.css
@@ -183,29 +183,71 @@ div.messages.info:before {
 
 /* =====================================================================
    Buttons
+
+   Hierarchy (Opera 2.x):
+     .button-primary  → filled brand color, bold, lifted: the page's "complete" action.
+     .form-submit / .button (default) → outlined in brand color: a button, but not THE button.
+     .button-secondary → outlined neutral grey: auxiliary action.
+     .button-danger → outlined red, fills on hover: destructive action.
+
+   Forms should mark exactly one button per page as #button_type => 'primary'.
+   Forms with a single submit and no explicit primary mark render as the
+   outlined default — still clearly a button, but not styled as if it
+   were competing with a primary action that doesn't exist.
    ===================================================================== */
 
+/* Default submit / .button — outlined in brand color, regular weight. */
 input.form-submit,
 button.form-submit,
-.button,
+.button {
+  color: var(--color-primary, #6e0e0a);
+  background: transparent;
+  border: 2px solid var(--color-primary, #6e0e0a);
+  border-radius: var(--button-border-radius, 0.25rem);
+  text-transform: var(--button-text-transform, uppercase);
+  letter-spacing: 0.025em;
+  line-height: 1.4;
+  text-align: center;
+  font-weight: 400;
+}
+
+/* Primary submit — filled brand color, bolder text, brand-tinted lift. */
 input.button-primary,
-button.button-primary,
+button.button-primary {
+  color: var(--button-text, #ffffff);
+  background: var(--button-bg, #6e0e0a);
+  border: 2px solid var(--button-bg, #6e0e0a);
+  border-radius: var(--button-border-radius, 0.25rem);
+  text-transform: var(--button-text-transform, uppercase);
+  letter-spacing: 0.025em;
+  line-height: 1.4;
+  text-align: center;
+  font-weight: 600;
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--color-primary, #6e0e0a) 35%, transparent);
+}
+
+/* jQuery UI button widgets — keep the filled brand styling they had
+   before; they're invoked from autocomplete/dropdown contexts where
+   the outlined default doesn't fit. */
 .ui-state-default,
 .ui-widget-content .ui-state-default,
 .ui-widget-header .ui-state-default {
   color: var(--button-text, #ffffff);
   background: var(--button-bg, #6e0e0a);
   border: none;
-  border-radius: var(--button-border-radius, 0);
+  border-radius: var(--button-border-radius, 0.25rem);
   text-transform: var(--button-text-transform, uppercase);
   letter-spacing: 0.025em;
   line-height: 1.4;
   text-align: center;
 }
 
-/* Prevent visited link color bleeding into buttons */
+/* Prevent visited link color bleeding into anchor-styled buttons */
 .button:link,
-.button:visited,
+.button:visited {
+  color: var(--color-primary, #6e0e0a);
+  text-decoration: none;
+}
 input.button-primary:link,
 input.button-primary:visited,
 button.button-primary:link,
@@ -214,20 +256,27 @@ button.button-primary:visited {
   text-decoration: none;
 }
 
+/* Hover / focus — outlined fills in with brand; primary deepens + grows shadow. */
 input.form-submit:hover,
 input.form-submit:focus,
 button.form-submit:hover,
 button.form-submit:focus,
 .button:hover,
-.button:focus,
+.button:focus {
+  color: var(--button-text, #ffffff);
+  background: var(--color-primary, #6e0e0a);
+}
 input.button-primary:hover,
 input.button-primary:focus,
 button.button-primary:hover,
 button.button-primary:focus {
   color: var(--button-text, #ffffff);
   background: var(--button-bg-hover, #580b08);
+  border-color: var(--button-bg-hover, #580b08);
+  box-shadow: 0 3px 10px color-mix(in srgb, var(--color-primary, #6e0e0a) 50%, transparent);
 }
 
+/* Active — slight darken across the board */
 input.form-submit:active,
 button.form-submit:active,
 .button:active,
@@ -235,6 +284,7 @@ input.button-primary:active,
 button.button-primary:active {
   color: var(--button-text, #ffffff);
   background: var(--button-bg-hover, #580b08);
+  border-color: var(--button-bg-hover, #580b08);
   filter: brightness(0.9);
 }
 

--- a/tokens.inc
+++ b/tokens.inc
@@ -146,7 +146,7 @@ $info = array(
     'button-border-radius' => array(
       'label'   => t('Button corner radius'),
       'type'    => 'text',
-      'default' => '0',
+      'default' => '0.25rem',
       'group'   => 'buttons',
     ),
     'button-text-transform' => array(


### PR DESCRIPTION
## Summary

Introduces a clear primary/default button hierarchy on Opera 2.x and rounds all actionable buttons per `DESIGN.md`.

- **Default `.form-submit` / `.button`** → outlined in brand color (transparent background, 2px primary-color border, regular weight). A button, but not THE button.
- **`.button-primary`** → filled brand color, heavier text (font-weight 600), brand-tinted box-shadow lift. The page's completion action.
- **`.button-secondary`** and **`.button-danger`** → unchanged.
- **`--button-border-radius`** default bumped from `0` → `0.25rem`. Matches the actionable-controls rule in `DESIGN.md`. Token registration default in `tokens.inc`, active config in `config/theme.tokens.opera.json`, and CSS fallback values across 5 component files all updated.
- **`.button-primary`** added to the shared padding/sizing rule in `backdrop-form.css` (it was previously missing, leaving primary buttons un-padded). Existing rule got `box-sizing: border-box` so the new 2px border doesn't bloat outer dimensions.

## Why

The existing rule lumped `.form-submit`, `.button`, and `.button-primary` into a single filled-maroon style. A form with multiple submits (Add row, Remove row, Complete) had no visible hierarchy — every button looked equally "primary." On a Drop Suite event-registration form this made the user's eye hunt for the actual completion action.

Forms should now mark exactly one button per page as `'#button_type' => 'primary'`. Forms with a single submit and no explicit primary mark render as the outlined default — still clearly a button, but not styled as if competing with a primary that doesn't exist.

## Breaking change

This is a behavioral change for Opera 2.x sites whose existing forms don't already mark `'#button_type' => 'primary'`. Their default submit buttons will render as outlined (transparent fill) instead of filled brand color. Considered acceptable on the 2.x beta line.